### PR TITLE
feat: align card height to 120px

### DIFF
--- a/meteo-card.js
+++ b/meteo-card.js
@@ -119,7 +119,7 @@ class MeteoCard extends LitElement {
     const tempHigh = this.today?.temperature ?? this.entity.attributes.temperature_high ?? currentTemp + 5;
 
     return html`
-      <ha-card class="weather-card ${bg}" style="height: 120px !important; min-height: 120px !important;">
+      <ha-card class="weather-card ${bg}">
         <div class="weather-content">
           <div class="location">${this._getLocationName()}</div>
           <div class="current-temp">${currentTemp}°</div>
@@ -136,14 +136,15 @@ class MeteoCard extends LitElement {
   static get styles() {
     return css`
       :host {
-        height: 120px !important;
-        min-height: 120px !important;
-        max-height: 120px !important;
+        --meteo-card-height: 120px;
+        height: var(--meteo-card-height) !important;
+        min-height: var(--meteo-card-height) !important;
+        max-height: var(--meteo-card-height) !important;
       }
 
       ha-card {
-        height: 120px !important;
-        min-height: 120px !important;
+        height: var(--meteo-card-height) !important;
+        min-height: var(--meteo-card-height) !important;
         border-radius: 16px;
         border: none;
         box-shadow: 0 4px 20px rgba(0,0,0,0.1);

--- a/test-hauteurs.html
+++ b/test-hauteurs.html
@@ -141,24 +141,24 @@
         <div class="info">
             <h2>📏 Comparaison des hauteurs</h2>
             <ul>
-                <li><strong>120px (très compact)</strong> : Police réduite, espacements minimum</li>
-                <li><strong>140px</strong> : Compact mais lisible</li>
-                <li><strong>160px (actuel)</strong> : Bon équilibre lisibilité/compacité</li>
-                <li><strong>180px</strong> : Plus d'espace, confortable</li>
+                <li><strong>120px (actuel)</strong> : Affichage complet et compact</li>
+                <li><strong>140px</strong> : Un peu plus d'espace</li>
+                <li><strong>160px</strong> : Confortable mais plus grand</li>
+                <li><strong>180px</strong> : Très spacieux</li>
             </ul>
-            
-            <h3>✅ Changements appliqués (160px)</h3>
+
+            <h3>✅ Changements appliqués (120px)</h3>
             <ul>
-                <li>Hauteur : 200px → <strong>160px</strong></li>
-                <li>Padding : 24px → <strong>16px</strong></li>
-                <li>Température : 64px → <strong>48px</strong></li>
-                <li>Ville : 18px → <strong>16px</strong></li>
-                <li>Condition : 16px → <strong>14px</strong></li>
-                <li>Min/Max : 16px → <strong>14px</strong></li>
+                <li>Hauteur : 160px → <strong>120px</strong></li>
+                <li>Padding : 16px → <strong>12px</strong></li>
+                <li>Température : 48px → <strong>36px</strong></li>
+                <li>Ville : 16px → <strong>14px</strong></li>
+                <li>Condition : 14px → <strong>12px</strong></li>
+                <li>Min/Max : 14px → <strong>12px</strong></li>
             </ul>
-            
+
             <h3>🎯 Si vous voulez encore plus compact</h3>
-            <p>Je peux créer une version 120px avec les polices encore plus petites.</p>
+            <p>Je peux créer une version 100px avec les polices encore plus petites.</p>
         </div>
     </div>
 </body>


### PR DESCRIPTION
## Summary
- centralize card height via --meteo-card-height variable defaulting to 120px
- update height comparison doc to reference 120px baseline

## Testing
- `./test.sh` *(fails: Docker n'est pas en cours d'exécution)*
- `node -c meteo-card.js`


------
https://chatgpt.com/codex/tasks/task_e_689ef170e62c8331a164a4458f2a6037